### PR TITLE
Faster parsing of classless annotations (BC break)

### DIFF
--- a/src/Reflection/AnnotationsParser.php
+++ b/src/Reflection/AnnotationsParser.php
@@ -42,6 +42,9 @@ class AnnotationsParser
 
 	/** @var Nette\Caching\IStorage */
 	private static $cacheStorage;
+	
+	/** @var array */
+	private static $classExistsCache = array();
 
 
 	/**
@@ -253,7 +256,8 @@ class AnnotationsParser
 			}
 
 			$class = $name . 'Annotation';
-			if (class_exists($class)) {
+			if (isset(self::$classExistsCache[$class]) && self::$classExistsCache[$class] === TRUE
+				|| self::$classExistsCache[$class] = class_exists($class)) {
 				$res[$name][] = new $class(is_array($value) ? $value : array('value' => $value));
 
 			} else {


### PR DESCRIPTION
Can significantly improve performance for project with abundance of annotations of non existent classes and slow class (auto)loaders.

BC break will occur for hacked libraries that rely on registering annotation classes previously deemed non existent while loading annotation class.

Example of BC break:

``` php
class Satan {
    /**
     * @hell
     * @purgatory
     * @hell
     */
    function hell() { }
}
```

``` php
function __autoload($class) // for brevity of example using discouraged method
{
    if ($class == 'purgatoryAnnotation') {
        require 'HellAnnotation.php';
        require 'PurgatoryAnnotation.php'; // because it inherits from HellAnnotation for whatever reason...
    }
}
```

_I can't get rid of the feeling we already discussed this. Not sure if that is the case or just a déjà vu._
