### PR TITLE
Added helper for traits-compatible getDeclaringClass

### DIFF
--- a/src/Reflection/Helpers.php
+++ b/src/Reflection/Helpers.php
@@ -18,26 +18,11 @@ class Helpers
 	/**
 	 * Unlike the PHP's getDeclaringClass method, this can return a trait reflection.
 	 * Results from this method should be cached.
-	 * @param \ReflectionProperty|\ReflectionMethod
 	 * @return Nette\Reflection\ClassType
 	 */
-	public static function getDeclaringClass(\Reflector $reflection)
+	public static function getDeclaringClass(\ReflectionProperty $reflection)
 	{	
-		$class = $reflection->getDeclaringClass();
-
-		if ($reflection instanceof \ReflectionProperty) {
-			$trait = self::searchTraitsForProperty($class, $reflection->getName());
-
-		} else {
-			$methodFile = $reflection->getFileName();
-			$methodStartLine = $reflection->getStartLine();
-			$methodEndLine = $reflection->getEndLine();
-			$trait = self::searchTraitsForMethod($class, $methodFile, $methodStartLine, $methodEndLine);
-		}
-
-		if ($trait !== NULL) {
-			$class = $trait;
-		}
+		$class = self::searchTraitsForProperty($reflection->getDeclaringClass(), $reflection->getName());
 
 		return new ClassType($class->getName());
 	}
@@ -49,31 +34,13 @@ class Helpers
 	private static function searchTraitsForProperty(\ReflectionClass $class, $name)
 	{
 		foreach ($class->getTraits() as $trait) {
-			$result = self::searchTraitsForProperty($trait, $name);
-			if ($result !== NULL) {
+			if ($result = self::searchTraitsForProperty($trait, $name)) {
 				return $result;
-
-			} elseif ($trait->hasProperty($name)) {
-				return $trait;
 			}
 		}
-	}
 
-
-	/**
-	 * Recursive method called to find a method in traits.
-	 */
-	private static function searchTraitsForMethod(\ReflectionClass $class, $methodFile, $methodStartLine, $methodEndLine)
-	{
-		foreach ($class->getTraits() as $trait) {
-			if ($trait->getFileName() === $methodFile && $trait->getStartLine() <= $methodStartLine && $trait->getEndLine() >= $methodEndLine) {
-				return $trait;
-			}
-
-			$result = self::searchTraitsForMethod($trait, $methodFile, $methodStartLine, $methodEndLine);
-			if ($result !== NULL) {
-				return $result;
-			}
+		if ($class->hasProperty($name)) {
+			return $class;
 		}
 	}
 

--- a/src/Reflection/Helpers.php
+++ b/src/Reflection/Helpers.php
@@ -18,16 +18,11 @@ class Helpers
 	/**
 	 * Unlike the PHP's getDeclaringClass method, this can return a trait reflection.
 	 * Results from this method should be cached.
-	 * @param \ReflectionProperty|\ReflectionMethod	 
+	 * @param \ReflectionProperty|\ReflectionMethod
 	 * @return Nette\Reflection\ClassType
-	 * @throws Nette\InvalidArgumentException	 
 	 */
 	public static function getDeclaringClass(\Reflector $reflection)
-	{
-		if (!$reflection instanceof \ReflectionProperty && !$reflection instanceof \ReflectionMethod) {
-			throw new \Nette\InvalidArgumentException('Expected argument of type \ReflectionProperty or \ReflectionMethod, ' . get_class($reflection) . ' given.');
-		}
-	
+	{	
 		$class = $reflection->getDeclaringClass();
 
 		if ($reflection instanceof \ReflectionProperty) {

--- a/src/Reflection/Helpers.php
+++ b/src/Reflection/Helpers.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Reflection;
+
+use Nette;
+
+
+/**
+ * @author Jáchym Toušek
+ */
+class Helpers
+{
+	/**
+	 * Unlike the PHP's getDeclaringClass method, this can return a trait reflection.
+	 * Results from this method should be cached.
+	 * @param \ReflectionProperty|\ReflectionMethod	 
+	 * @return Nette\Reflection\ClassType
+	 * @throws Nette\InvalidArgumentException	 
+	 */
+	public static function getDeclaringClass(\Reflector $reflection)
+	{
+		if (!$reflection instanceof \ReflectionProperty && !$reflection instanceof \ReflectionMethod) {
+			throw new \Nette\InvalidArgumentException('Expected argument of type \ReflectionProperty or \ReflectionMethod, ' . get_class($reflection) . ' given.');
+		}
+	
+		$class = $reflection->getDeclaringClass();
+
+		if ($reflection instanceof \ReflectionProperty) {
+			$trait = self::searchTraitsForProperty($class, $reflection->getName());
+
+		} else {
+			$methodFile = $reflection->getFileName();
+			$methodStartLine = $reflection->getStartLine();
+			$methodEndLine = $reflection->getEndLine();
+			$trait = self::searchTraitsForMethod($class, $methodFile, $methodStartLine, $methodEndLine);
+		}
+
+		if ($trait !== NULL) {
+			$class = $trait;
+		}
+
+		return new ClassType($class->getName());
+	}
+
+
+	/**
+	 * Recursive method called to find a property in traits.
+	 */
+	private static function searchTraitsForProperty(\ReflectionClass $class, $name)
+	{
+		foreach ($class->getTraits() as $trait) {
+			$result = self::searchTraitsForProperty($trait, $name);
+			if ($result !== NULL) {
+				return $result;
+
+			} elseif ($trait->hasProperty($name)) {
+				return $trait;
+			}
+		}
+	}
+
+
+	/**
+	 * Recursive method called to find a method in traits.
+	 */
+	private static function searchTraitsForMethod(\ReflectionClass $class, $methodFile, $methodStartLine, $methodEndLine)
+	{
+		foreach ($class->getTraits() as $trait) {
+			if ($trait->getFileName() === $methodFile && $trait->getStartLine() <= $methodStartLine && $trait->getEndLine() >= $methodEndLine) {
+				return $trait;
+			}
+
+			$result = self::searchTraitsForMethod($trait, $methodFile, $methodStartLine, $methodEndLine);
+			if ($result !== NULL) {
+				return $result;
+			}
+		}
+	}
+
+}

--- a/tests/Reflection/Helpers.getDeclatingClass.phpt
+++ b/tests/Reflection/Helpers.getDeclatingClass.phpt
@@ -14,21 +14,17 @@ require __DIR__ . '/../bootstrap.php';
 trait A
 {
 	protected $bar;
-	protected function bar() {}
-	protected function override() {}
 }
 
 trait B
 {
 	use A;
 	protected $foo;
-	protected function foo() {}
 }
 
 trait E
 {
 	protected $baz;
-	protected function baz() {} 
 }
 
 class C
@@ -36,8 +32,6 @@ class C
 	use B;
 	use E;
 	protected $own;
-	protected function own() {}
-	protected function override() {}
 }
 
 class D extends C
@@ -59,24 +53,4 @@ test(function() { // Property in class itself
 
 test(function() { // Property in second trait
 	Assert::same('E', Reflection\Helpers::getDeclaringClass(new \ReflectionProperty('D', 'baz'))->getName());
-});
-
-test(function() { // Method in trait
-	Assert::same('B', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'foo'))->getName());
-});
-
-test(function() { // Method in parent trait
-	Assert::same('A', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'bar'))->getName());
-});
-
-test(function() { // Method in class itself
-	Assert::same('C', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'own'))->getName());
-});
-
-test(function() { // Method in second trait
-	Assert::same('E', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'baz'))->getName());
-});
-
-test(function() { // Method in trait overridden by class
-	Assert::same('C', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'override'))->getName());
 });

--- a/tests/Reflection/Helpers.getDeclatingClass.phpt
+++ b/tests/Reflection/Helpers.getDeclatingClass.phpt
@@ -25,9 +25,16 @@ trait B
 	protected function foo() {}
 }
 
+trait E
+{
+	protected $baz;
+	protected function baz() {} 
+}
+
 class C
 {
 	use B;
+	use E;
 	protected $own;
 	protected function own() {}
 	protected function override() {}
@@ -50,6 +57,10 @@ test(function() { // Property in class itself
 	Assert::same('C', Reflection\Helpers::getDeclaringClass(new \ReflectionProperty('D', 'own'))->getName());
 });
 
+test(function() { // Property in second trait
+	Assert::same('E', Reflection\Helpers::getDeclaringClass(new \ReflectionProperty('D', 'baz'))->getName());
+});
+
 test(function() { // Method in trait
 	Assert::same('B', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'foo'))->getName());
 });
@@ -60,6 +71,10 @@ test(function() { // Method in parent trait
 
 test(function() { // Method in class itself
 	Assert::same('C', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'own'))->getName());
+});
+
+test(function() { // Method in second trait
+	Assert::same('E', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'baz'))->getName());
 });
 
 test(function() { // Method in trait overridden by class

--- a/tests/Reflection/Helpers.getDeclatingClass.phpt
+++ b/tests/Reflection/Helpers.getDeclatingClass.phpt
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Test: Nette\Reflection\Helpers::getDeclaringClass.
+ */
+
+use Nette\Reflection,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+trait A
+{
+	protected $bar;
+	protected function bar() {}
+	protected function override() {}
+}
+
+trait B
+{
+	use A;
+	protected $foo;
+	protected function foo() {}
+}
+
+class C
+{
+	use B;
+	protected $own;
+	protected function own() {}
+	protected function override() {}
+}
+
+class D extends C
+{
+}
+
+
+test(function() { // Property in trait
+	Assert::same('B', Reflection\Helpers::getDeclaringClass(new \ReflectionProperty('D', 'foo'))->getName());
+});
+
+test(function() { // Property in parent trait
+	Assert::same('A', Reflection\Helpers::getDeclaringClass(new \ReflectionProperty('D', 'bar'))->getName());
+});
+
+test(function() { // Property in class itself
+	Assert::same('C', Reflection\Helpers::getDeclaringClass(new \ReflectionProperty('D', 'own'))->getName());
+});
+
+test(function() { // Method in trait
+	Assert::same('B', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'foo'))->getName());
+});
+
+test(function() { // Method in parent trait
+	Assert::same('A', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'bar'))->getName());
+});
+
+test(function() { // Method in class itself
+	Assert::same('C', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'own'))->getName());
+});
+
+test(function() { // Method in trait overridden by class
+	Assert::same('C', Reflection\Helpers::getDeclaringClass(new \ReflectionMethod('D', 'override'))->getName());
+});


### PR DESCRIPTION
The `ReflectionProperty::getDeclaringClass()` doesn't work with traits, it instead always returns the class which used the trait, not the actual trait that declared the property. The same goes for ReflectionMethod as well.

This affects for example the `@inject` annotations from Nette\DI and the `@autowire` annotations from Kdyby\Autowired.

**Example:**
```php
// FooTrait.php
namespace Foo;
use Foo\Model\Service;
trait FooTrait {
	/** @var Service @inject */
	public $service;
}

// FooPresenter.php
namespace Foo;
class FooPresenter extends \Nette\Application\UI\Presenter
{
	use FooTrait;
}
```

*With such code the DI container won't be able to inject the Foo\Model\Service class because it will look to the use statements in FooPresenter.php and look for class Foo\Service instead.*

**Limitations of the solution:**
- When the property is declared in multiple traits, the PHP emits some kind of warning. If this warning is ignored, this won't work correctly.
- This solution wouldn't work for methods renamed using `use FooTrait { method as newMethod }`.

**TODO:**
- Tests.
- Add the same for methods.
- Discuss the class & methods names & parameters.
- Discuss possible integration into `AnnotationsParser::expandClassName()` - it could accept ReflectionMethod and ReflectionProperty as well and search for the class/trait using this.

**Related links:**
- https://github.com/Kdyby/Autowired/issues/17
- http://mouf-php.com/blog/php_reflection_api_traits

@dg I'd like to hear your thoughts about this before working on it further. Mainly whether you want such solution in Nette at all.
