### PR TITLE
Return even classes without annotations when using parsePhp

### DIFF
--- a/src/Reflection/AnnotationsParser.php
+++ b/src/Reflection/AnnotationsParser.php
@@ -299,6 +299,7 @@ class AnnotationsParser
 					if ($name = self::fetch($tokens, T_STRING)) {
 						$class = $namespace . $name;
 						$classLevel = $level + 1;
+						$res[$class] = [];
 						if ($docComment) {
 							$res[$class]['class'] = $docComment;
 						}

--- a/tests/Reflection/AnnotationsParser.parsePhp.phpt
+++ b/tests/Reflection/AnnotationsParser.parsePhp.phpt
@@ -27,11 +27,13 @@ Assert::same([
 		'g' => '/** @return g */',
 	],
 	'Test\AnnotatedClass2' => ['class' => '/** @author jack */'],
+	'Test\AnnotatedClass3' => [],
 ], AnnotationsParser::parsePhp(file_get_contents(__DIR__ . '/files/annotations.php')));
 
 
 Assert::same([
 	'Test\TestClass1' => ['use' => ['C' => 'A\B']],
 	'Test\TestClass2' => ['use' => ['C' => 'A\B', 'D' => 'D', 'E' => 'E', 'H' => 'F\G']],
+	'Test2\TestClass3' => [],
 	'Test2\TestClass4' => ['use' => ['C' => 'A\B\C']],
 ], AnnotationsParser::parsePhp(file_get_contents(__DIR__ . '/files/uses.php')));


### PR DESCRIPTION
Hi,
I'm using `AnnotationsParser::parsePhp()` method to retrieve FQN of classes in php string, then instantiating those classes using something like `$reflectionClass = new \ReflectionClass($className))`.

However, `parsePhp()` won't return name of the classes if they don't have any annotation or at least any `use` statement. This is quite limiting, as I want to read name of the class no mater if it has any annotations/use statements or not - the exact content of annotations could be checked later (with eg. `AnnotationsParser::getAll($reflectionClass)`).

Currently there is no way determining whether the file don't contain any class at all, or just class without annotations. 

I prepared PoC that changed the behavior. I'm not sure it there any reason for the current behavior or if this change would break something? If so, this behavior could be at least triggered optionally. What do you think?

Parsing this file with `parsePhp()` will result in null being returned:
```php
<?php

namespace Foo;

class Bar extends Baz\Ban\AbstractBar
{
    public function do()
    {
        ...
    }
}
```

But this will return `['Foo\Bar' => ['use' => ['AbstractBar' => 'Baz\Ban\AbstractBar']]]`:
```php
<?php

namespace Foo;

use Baz\Ban\AbstractBar;

class Bar extends AbstractBar
{
    public function do()
    {
        ...
    }
}
```